### PR TITLE
venv fix + fix for container run (macOS)

### DIFF
--- a/.venv
+++ b/.venv
@@ -7,6 +7,8 @@
 
 
 
+# save current PS1
+_ORIGINAL_PS1="$PS1"
 
 # ensure sourcing
 if [ "${BASH_SOURCE-}" = "$0" ]; then
@@ -27,6 +29,18 @@ for dependency in "pwd" "alias" "unalias" "realpath"; do
         return
     fi
 done
+
+# modify PS1 to indicate that venv is active
+PS1="(.venv) $_ORIGINAL_PS1"
+
+# deactivate venv
+deactivate_venv() {
+    PS1="$_ORIGINAL_PS1"
+    unset _ORIGINAL_PS1
+    unset PROJECT_ROOT
+    unset VIRTUAL_ROOT
+    unset -f deactivate_venv
+}
 
 # paths
 PROJECT_ROOT=$(pwd)

--- a/doc/postgres.md
+++ b/doc/postgres.md
@@ -26,10 +26,9 @@ Open terminal inside **repository root**.
         -d docker.io/postgis/postgis
     ```
     
-    On __MacOS__, the way _Docker_ and _Podman_ handle user permissions
-    can be tricky, especially when it comes to mounted volumes.
-    Instead of mounting a host directory, use a named volume,
-    for example, `otrails_data`
+    On __MacOS__ set the user namespace mode for the container to `keep-id`
+    in order to map the current __MacOS__ user to the same UID within the
+    container:
 
     ```bash
     podman run \
@@ -39,7 +38,8 @@ Open terminal inside **repository root**.
         -e PGDATA=/var/lib/postgresql/data/pgdata \
         --name otrails-postgis \
         -p 0.0.0.0:5432:5432 \
-        -v otrails_data:/var/lib/postgresql/data \
+        -v $(pwd)/data/pg:/var/lib/postgresql/data \
+        --userns=keep-id \
         -d docker.io/postgis/postgis
     ```
 


### PR DESCRIPTION
### .venv

changes to the virtual environment activation and deactivation process:

**Virtual Environment Indicator**: The PS1 prompt is now modified to include an indicator when the virtual environment is active. This makes it easier to see at a glance whether the virtual environment is currently active.

**Deactivation Function**: A new function, `deactivate_venv`, has been added. This function deactivates the virtual environment and restores the original PS1 prompt. It also unsets the environment variables and functions related to the virtual environment.

These changes improve the user experience when working with the virtual environment by making the activation and deactivation process more transparent and easier to manage.

### doc/postgres.md

update to the `podman run` command for _MacOS_ users:

The `podman run` command has been modified to include the `--userns=keep-id` option. This ensures that the user namespace is kept the same inside and outside the container, preserving the user's UID and GID.
